### PR TITLE
Removed unnecessary periods and fixed typos in Imprint

### DIFF
--- a/pages/holding/imprint.ts
+++ b/pages/holding/imprint.ts
@@ -29,7 +29,7 @@ Body(Box(
         ).addClass("block"),
         Label(`Netiquette and Site Guidelines`, "h3"),
         Label(
-            `For many years, BBN Holding strives to provide helpful and relevant information on the BBN Holding company website. BBN Holding also shares news and information about latest events on maritime\xA0websites or social platforms like LinkedIn. We are happy to connect with you and read your feedback`,
+            `For many years, BBN Holding strives to provide helpful and relevant information on the BBN Holding company website. BBN Holding also shares news and information about latest events on maritime\xA0websites or social platforms like LinkedIn. We are happy to connect with you and read your feedback!`,
         ).addClass("block"),
         Label(`Please keep in mind: comments should be relevant and on-topic. Inappropriate or offensive comments, and in particular those that contain false\xA0/ misleading information or that engage in personal attacks (and similar), may be deleted.`).addClass("block"),
         Label(`In case of any questions, please send us an email: support@bbn.one`).addClass("block"),

--- a/pages/holding/imprint.ts
+++ b/pages/holding/imprint.ts
@@ -22,16 +22,16 @@ Body(Box(
         ).addClass("block").setAlignItems("center"),
         Label(`Contents`, "h3"),
         Label(
-            `BBN Holding regularly examines and updates the contents of this website. However we give no guarantee for the accuracy, completeness, timeliness or reliability of the information provided and are not liable for claims resulting directly or indirectly from flawed or erroneous informat`,
+            `BBN Holding regularly examines and updates the contents of this website. However we give no guarantee for the accuracy, completeness, timeliness or reliability of the information provided and are not liable for claims resulting directly or indirectly from flawed or erroneous information`,
         ).addClass("block"),
         Label(
-            `In order to offer our customers additional information we occasionally provide links to other websites. We herewith state explicitly that we have no influence on the set-up, the timeliness or the contents of linked pages. For this reason we distance ourselves expressly from all contents on the pages linked with this Homepage and disclaim all forms of liability for these as well. We are not aware of any content which is illegal, objectionable or contrary to the rules of fair competition. Please inform BBN Holding if you believe that a linked page infringes upon these princip`,
+            `In order to offer our customers additional information we occasionally provide links to other websites. We herewith state explicitly that we have no influence on the set-up, the timeliness or the contents of linked pages. For this reason we distance ourselves expressly from all contents on the pages linked with this Homepage and disclaim all forms of liability for these as well. We are not aware of any content which is illegal, objectionable or contrary to the rules of fair competition. Please inform BBN Holding if you believe that a linked page infringes upon these principles`,
         ).addClass("block"),
         Label(`Netiquette and Site Guidelines`, "h3"),
         Label(
-            `For many years, BBN Holding strives to provide helpful and relevant information on the BBN Holding company website. BBN Holding also shares news and information about latest events on maritime\xA0websites or social platforms like LinkedIn. We are happy to connect with you and read your feedb`,
+            `For many years, BBN Holding strives to provide helpful and relevant information on the BBN Holding company website. BBN Holding also shares news and information about latest events on maritime\xA0websites or social platforms like LinkedIn. We are happy to connect with you and read your feedback`,
         ).addClass("block"),
-        Label(`Please keep in mind: comments should be relevant and on-topic. Inappropriate or offensive comments, and in particular those that contain false\xA0/ misleading information or that engage in personal attacks (and similar), may be dele`).addClass("block"),
+        Label(`Please keep in mind: comments should be relevant and on-topic. Inappropriate or offensive comments, and in particular those that contain false\xA0/ misleading information or that engage in personal attacks (and similar), may be deleted`).addClass("block"),
         Label(`In case of any questions, please send us an email: support@bbn.one`).addClass("block"),
         Label(`Copyrights/Trademark rights`, "h3"),
         Label(

--- a/pages/holding/imprint.ts
+++ b/pages/holding/imprint.ts
@@ -22,7 +22,7 @@ Body(Box(
         ).addClass("block").setAlignItems("center"),
         Label(`Contents`, "h3"),
         Label(
-            `BBN Holding regularly examines and updates the contents of this website. However we give no guarantee for the accuracy, completeness, timeliness or reliability of the information provided and are not liable for claims resulting directly or indirectly from flawed or erroneous information`,
+            `BBN Holding regularly examines and updates the contents of this website. However we give no guarantee for the accuracy, completeness, timeliness or reliability of the information provided and are not liable for claims resulting directly or indirectly from flawed or erroneous information.`,
         ).addClass("block"),
         Label(
             `In order to offer our customers additional information we occasionally provide links to other websites. We herewith state explicitly that we have no influence on the set-up, the timeliness or the contents of linked pages. For this reason we distance ourselves expressly from all contents on the pages linked with this Homepage and disclaim all forms of liability for these as well. We are not aware of any content which is illegal, objectionable or contrary to the rules of fair competition. Please inform BBN Holding if you believe that a linked page infringes upon these principles`,

--- a/pages/holding/imprint.ts
+++ b/pages/holding/imprint.ts
@@ -25,7 +25,7 @@ Body(Box(
             `BBN Holding regularly examines and updates the contents of this website. However we give no guarantee for the accuracy, completeness, timeliness or reliability of the information provided and are not liable for claims resulting directly or indirectly from flawed or erroneous information.`,
         ).addClass("block"),
         Label(
-            `In order to offer our customers additional information we occasionally provide links to other websites. We herewith state explicitly that we have no influence on the set-up, the timeliness or the contents of linked pages. For this reason we distance ourselves expressly from all contents on the pages linked with this Homepage and disclaim all forms of liability for these as well. We are not aware of any content which is illegal, objectionable or contrary to the rules of fair competition. Please inform BBN Holding if you believe that a linked page infringes upon these principles`,
+            `In order to offer our customers additional information we occasionally provide links to other websites. We herewith state explicitly that we have no influence on the set-up, the timeliness or the contents of linked pages. For this reason we distance ourselves expressly from all contents on the pages linked with this Homepage and disclaim all forms of liability for these as well. We are not aware of any content which is illegal, objectionable or contrary to the rules of fair competition. Please inform BBN Holding if you believe that a linked page infringes upon these principles.`,
         ).addClass("block"),
         Label(`Netiquette and Site Guidelines`, "h3"),
         Label(

--- a/pages/holding/imprint.ts
+++ b/pages/holding/imprint.ts
@@ -31,7 +31,7 @@ Body(Box(
         Label(
             `For many years, BBN Holding strives to provide helpful and relevant information on the BBN Holding company website. BBN Holding also shares news and information about latest events on maritime\xA0websites or social platforms like LinkedIn. We are happy to connect with you and read your feedback`,
         ).addClass("block"),
-        Label(`Please keep in mind: comments should be relevant and on-topic. Inappropriate or offensive comments, and in particular those that contain false\xA0/ misleading information or that engage in personal attacks (and similar), may be deleted`).addClass("block"),
+        Label(`Please keep in mind: comments should be relevant and on-topic. Inappropriate or offensive comments, and in particular those that contain false\xA0/ misleading information or that engage in personal attacks (and similar), may be deleted.`).addClass("block"),
         Label(`In case of any questions, please send us an email: support@bbn.one`).addClass("block"),
         Label(`Copyrights/Trademark rights`, "h3"),
         Label(

--- a/pages/holding/imprint.ts
+++ b/pages/holding/imprint.ts
@@ -35,7 +35,7 @@ Body(Box(
         Label(`In case of any questions, please send us an email: support@bbn.one`).addClass("block"),
         Label(`Copyrights/Trademark rights`, "h3"),
         Label(
-            `All rights to the texts, photos, graphics, video files and other objects on these Internet pages are protected by copyright.Their download, reproduction or use in other media or publications requires our written consent.All rights to all of the trademarks on this page belong exclusively to the owners of these trademarks`,
+            `All rights to the texts, photos, graphics, video files and other objects on these Internet pages are protected by copyright.Their download, reproduction or use in other media or publications requires our written consent.All rights to all of the trademarks on this page belong exclusively to the owners of these trademarks.`,
         ).addClass("block"),
     ).addClass("flow-text"),
     Footer(),

--- a/pages/holding/imprint.ts
+++ b/pages/holding/imprint.ts
@@ -35,7 +35,7 @@ Body(Box(
         Label(`In case of any questions, please send us an email: support@bbn.one`).addClass("block"),
         Label(`Copyrights/Trademark rights`, "h3"),
         Label(
-            `All rights to the texts, photos, graphics, video files and other objects on these Internet pages are protected by copyright.Their download, reproduction or use in other media or publications requires our written consent.All rights to all of the trademarks on this page belong exclusively to the owners of these trademark`,
+            `All rights to the texts, photos, graphics, video files and other objects on these Internet pages are protected by copyright.Their download, reproduction or use in other media or publications requires our written consent.All rights to all of the trademarks on this page belong exclusively to the owners of these trademarks`,
         ).addClass("block"),
     ).addClass("flow-text"),
     Footer(),

--- a/pages/music-landing/main.ts
+++ b/pages/music-landing/main.ts
@@ -54,7 +54,7 @@ Body(
         Content(
             Grid(
                 Box(
-                    Label("Drop in with\nyour Audience.")
+                    Label("Drop in with\nyour Audience")
                         .setTextSize("7xl")
                         .setTextAlign("start")
                         .setBalanced()
@@ -304,11 +304,11 @@ Body(
                 .setMaxWidth("900px"),
         ),
         Grid(
-            Label("Loved by Artists.")
+            Label("Loved by Artists")
                 .setFontWeight("bold")
                 .setTextSize("6xl")
                 .setTextAlign("center"),
-            Label("See how our Artists value BBN Music.")
+            Label("See how our Artists value BBN Music")
                 .setTextAlign("center")
                 .setFontWeight("bold")
                 .setTextSize("xl")


### PR DESCRIPTION
Btw its my first time reading an imprint so subconsciously I think two possibilities are there: 1. Lawyers are poor in english 2. Imprint was rushed.
Please review the 2nd commit (I really don't wanna be sued 🙏)
In the first commit I removed some periods (unnecessary) that were present in the headings and such. 
I didnt wanna touch the Imprint a lot (scared to death) so you might wanna review if sentences in the Imprint should end with a period (they don't, yet) and in some places sentences start after a period rightaway with the absence of a whitespace (eg: ...s are protected by copyright.Their download, reproduction or use...)

**TLDR by GPT: Reviewing the second commit to ensure it's legally sound. Initially, removed unnecessary periods but didn't heavily edit the Imprint section. Concerned about potential legal issues due to lack of proper grammar and rushed publication.**

> As a sidenote, I need to do some actual stuff instead of reading and fixing legal pages (who actually reads this 💀 )